### PR TITLE
Storing Github Token in Keychain

### DIFF
--- a/githubmirror/__init__.py
+++ b/githubmirror/__init__.py
@@ -27,7 +27,7 @@ def cmd():
     else:
         workdir = os.getcwd()
 
-    org = main.get_organization(args['<organization>'], workdir)
+    org = main.get_organization(args['<organization>'])
     if args['--only-repo']:
         repos = [org.get_repo(args['--only-repo'])]
     else:

--- a/githubmirror/main.py
+++ b/githubmirror/main.py
@@ -2,39 +2,23 @@
 
 import os
 import sys
-import git
 import json
+import git
 import github
+import keyring  # https://pypi.python.org/pypi/keyring
 
 REMOTE_NAME = 'origin'
 
 
-def setup_config_file(workdir):
-    config = dict()
-    with open(get_workdir_path('.githubmirror', workdir), 'w') as config_file:
-        prompt = ("Please give me a Github API token, "
+def setup_config():
+    prompt = ("Please give me a Github API token, "
                   "create on https://github.com/settings/applications : ")
-        auth_token = raw_input(prompt)
-        config = dict(auth_token=auth_token)
-        json.dump(config, config_file)
-    return config
-
-
-def get_config_file(workdir):
-    if not os.path.isfile(get_workdir_path('.githubmirror', workdir)):
-        setup_config_file(workdir)
-
-    with file(get_workdir_path('.githubmirror', workdir)) as f:
-        try:
-            config = json.load(f)
-        except ValueError:
-            return setup_config_file(workdir)
-        return config
+    auth_token = raw_input(prompt).strip()
+    keyring.set_password('githubmirror_token', 'githubmirror', auth_token)
 
 
 def get_auth_token(workdir):
-    config = get_config_file(workdir)
-    return config.get('auth_token')
+    return keyring.get_password('githubmirror_token', 'githubmirror')
 
 
 def get_github_client(workdir):
@@ -50,7 +34,7 @@ def get_organization(organization_name, workdir):
             org = gh.get_organization(organization_name)
         except github.GithubException as e:
             print >>sys.stderr, "Github error: %s" % e
-            setup_config_file(workdir)
+            setup_config()
     return org
 
 

--- a/githubmirror/main.py
+++ b/githubmirror/main.py
@@ -17,17 +17,16 @@ def setup_config():
     keyring.set_password('githubmirror_token', 'githubmirror', auth_token)
 
 
-def get_auth_token(workdir):
+def get_auth_token():
     return keyring.get_password('githubmirror_token', 'githubmirror')
 
 
-def get_github_client(workdir):
-    token = get_auth_token(workdir)
-    return github.Github(token)
+def get_github_client():
+    return github.Github(get_auth_token())
 
 
-def get_organization(organization_name, workdir):
-    gh = get_github_client(workdir)
+def get_organization(organization_name):
+    gh = get_github_client()
     org = None
     while not org:
         try:

--- a/githubmirror/main.py
+++ b/githubmirror/main.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import json
 import git
 import github
 import keyring  # https://pypi.python.org/pypi/keyring
@@ -10,30 +9,31 @@ import keyring  # https://pypi.python.org/pypi/keyring
 REMOTE_NAME = 'origin'
 
 
-def setup_config():
+def store_auth_token(organization_name):
     prompt = ("Please give me a Github API token, "
-                  "create on https://github.com/settings/applications : ")
-    auth_token = raw_input(prompt).strip()
-    keyring.set_password('githubmirror_token', 'githubmirror', auth_token)
+              "create on https://github.com/settings/applications : ")
+    auth_token = raw_input(prompt)
+    keyring.set_password('githubmirror', organization_name, auth_token)
 
 
-def get_auth_token():
-    return keyring.get_password('githubmirror_token', 'githubmirror')
+def get_auth_token(organization_name):
+    return keyring.get_password('githubmirror', organization_name)
 
 
-def get_github_client():
-    return github.Github(get_auth_token())
+def get_github_client(organization_name):
+    token = get_auth_token(organization_name)
+    return github.Github(token)
 
 
 def get_organization(organization_name):
-    gh = get_github_client()
+    gh = get_github_client(organization_name)
     org = None
     while not org:
         try:
             org = gh.get_organization(organization_name)
         except github.GithubException as e:
             print >>sys.stderr, "Github error: %s" % e
-            setup_config()
+            store_auth_token(organization_name)
     return org
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 GitPython==0.3.2.RC1
 PyGithub
 docopt
+keyring


### PR DESCRIPTION
Removed the config_file and used [keyring](https://pypi.python.org/pypi/keyring) to store the Github Token.

Tested on Mac OSX 10.9.2.
